### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/v-lodeva/f4658a55-0ee8-4456-acc1-8b676f46f94f/949b8a96-5ad7-45be-9106-16ef55ccae33/_apis/work/boardbadge/35209ae8-ea54-48e0-903d-0472fa11d54d)](https://dev.azure.com/v-lodeva/f4658a55-0ee8-4456-acc1-8b676f46f94f/_boards/board/t/949b8a96-5ad7-45be-9106-16ef55ccae33/Microsoft.RequirementCategory)
 # Visual Studio App Center Sample App for Android 
 The Android application in this repository and its corresponding tutorials will help you quickly and easily onboard to Visual Studio App Center.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#36](https://dev.azure.com/v-lodeva/f4658a55-0ee8-4456-acc1-8b676f46f94f/_workitems/edit/36). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.